### PR TITLE
Correct error property path value when field is in a nested array

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,8 @@ module.exports = function(schema, options) {
 			}
 
 			schema.path(pathname).validate(function(value) {
-				if (!value) return true;
-
-				return parseInt(value) === value;
+				if (value && parseInt(value) !== value)
+					this.invalidate(pathname, pathMessage, value);
 			}, pathMessage);
 		}
 	};

--- a/test/helper.js
+++ b/test/helper.js
@@ -78,7 +78,7 @@ module.exports = {
 			}
 		});
 
-		nestedSchema.plugin(mongooseInteger);
+		nestedSchema.plugin(integerValidation);
 
 		return new mongoose.Schema({
 			nested: nestedSchema

--- a/test/index.js
+++ b/test/index.js
@@ -11,4 +11,6 @@ mongoose.connection.on('error', function() {
 describe('Mongoose Integer', function() {
 	require('./tests/validation')();
 	require('./tests/message')();
+	require('./tests/path')();
+	require('./tests/value')();
 });

--- a/test/tests/message.js
+++ b/test/tests/message.js
@@ -5,7 +5,7 @@ var mongoose = require('mongoose');
 var should = require('should');
 
 var helper = require('../helper');
-var integerValidation = require('../index');
+var integerValidation = require('../../index');
 
 module.exports = function() {
 

--- a/test/tests/path.js
+++ b/test/tests/path.js
@@ -1,0 +1,73 @@
+/* jshint node: true, mocha: true */
+'use strict';
+
+var mongoose = require('mongoose');
+var should = require('should');
+
+var helper = require('../helper');
+var integerValidation = require('../../index');
+
+module.exports = function() {
+
+	describe('Path', function() {
+		afterEach(helper.afterEach);
+
+		it('should validate path for basic field', function(done) {
+			var Integer = mongoose.model('Integer', helper.createIntegerSchema().plugin(integerValidation));
+
+			new Integer({
+				value: 0.5
+			}).save(function(err) {
+				should.exist(err);
+				err.errors.value.path.should.equal('value');
+				done();
+			});
+		});
+
+		it('should validate path for nested field', function(done) {
+			var Integer = mongoose.model('Integer', helper.createIntegerNestedObjectSchema().plugin(integerValidation));
+
+			new Integer({
+				nested: {
+					value: 0.5
+				}
+			}).save(function(err) {
+				should.exist(err);
+				err.errors['nested.value'].path.should.equal('nested.value');
+				done();
+			});
+		});
+
+		it('should validate path for nested array field', function(done) {
+			var Integer = mongoose.model('Integer', helper.createIntegerNestedObjectArraySchema().plugin(integerValidation));
+
+			new Integer({
+				nested: [{
+					value: 0.5
+				}]
+			}).save(function(err) {
+				should.exist(err);
+				err.errors['nested.0.value'].path.should.equal('nested.0.value');
+				done();
+			});
+		});
+
+		it('should validate path for nested array nested array field', function(done) {
+			var Integer = mongoose.model('Integer', helper.createIntegerNestedNestedObjectArraySchema().plugin(integerValidation));
+
+			new Integer({
+				nested: [{
+					nested: [{
+						value: 0.5
+					}]
+				}]
+			}).save(function(err) {
+				should.exist(err);
+				err.errors['nested.0.nested.0.value'].path.should.equal('nested.0.nested.0.value');
+				done();
+			});
+		});
+
+		
+	});
+};

--- a/test/tests/validation.js
+++ b/test/tests/validation.js
@@ -13,7 +13,6 @@ module.exports = function() {
 		afterEach(helper.afterEach);
 
 		it('throws error if value is not an integer', function(done) {
-			console.log(integerValidation);
 			var Integer = mongoose.model('Integer', helper.createIntegerSchema().plugin(integerValidation));
 
 			new Integer({
@@ -156,7 +155,7 @@ module.exports = function() {
 		});
 
 		it('should throw no error on null values', function(done) {
-			var Integer = mongoose.model('Integer', helper.createDefaultNullIntegerSchema().plugin(mongooseInteger));
+			var Integer = mongoose.model('Integer', helper.createDefaultNullIntegerSchema().plugin(integerValidation));
 
 			new Integer().save(function(err) {
 				should.not.exist(err);

--- a/test/tests/validation.js
+++ b/test/tests/validation.js
@@ -5,7 +5,7 @@ var mongoose = require('mongoose');
 var should = require('should');
 
 var helper = require('../helper');
-var integerValidation = require('../index');
+var integerValidation = require('../../index');
 
 module.exports = function() {
 
@@ -13,6 +13,7 @@ module.exports = function() {
 		afterEach(helper.afterEach);
 
 		it('throws error if value is not an integer', function(done) {
+			console.log(integerValidation);
 			var Integer = mongoose.model('Integer', helper.createIntegerSchema().plugin(integerValidation));
 
 			new Integer({

--- a/test/tests/value.js
+++ b/test/tests/value.js
@@ -1,0 +1,73 @@
+/* jshint node: true, mocha: true */
+'use strict';
+
+var mongoose = require('mongoose');
+var should = require('should');
+
+var helper = require('../helper');
+var integerValidation = require('../../index');
+
+module.exports = function() {
+
+	describe('Value', function() {
+		afterEach(helper.afterEach);
+
+		it('should validate value for basic field', function(done) {
+			var Integer = mongoose.model('Integer', helper.createIntegerSchema().plugin(integerValidation));
+
+			new Integer({
+				value: 0.5
+			}).save(function(err) {
+				should.exist(err);
+				err.errors.value.value.should.equal(0.5);
+				done();
+			});
+		});
+
+		it('should validate value for nested field', function(done) {
+			var Integer = mongoose.model('Integer', helper.createIntegerNestedObjectSchema().plugin(integerValidation));
+
+			new Integer({
+				nested: {
+					value: 0.5
+				}
+			}).save(function(err) {
+				should.exist(err);
+				err.errors['nested.value'].value.should.equal(0.5);
+				done();
+			});
+		});
+
+		it('should validate value for nested array field', function(done) {
+			var Integer = mongoose.model('Integer', helper.createIntegerNestedObjectArraySchema().plugin(integerValidation));
+
+			new Integer({
+				nested: [{
+					value: 0.5
+				}]
+			}).save(function(err) {
+				should.exist(err);
+				err.errors['nested.0.value'].value.should.equal(0.5);
+				done();
+			});
+		});
+
+		it('should validate value for nested array nested array field', function(done) {
+			var Integer = mongoose.model('Integer', helper.createIntegerNestedNestedObjectArraySchema().plugin(integerValidation));
+
+			new Integer({
+				nested: [{
+					nested: [{
+						value: 0.5
+					}]
+				}]
+			}).save(function(err) {
+				should.exist(err);
+				err.errors['nested.0.nested.0.value'].value.should.equal(0.5);
+				done();
+			});
+		});
+
+		
+	});
+};


### PR DESCRIPTION
When the field is in a nested array, the error object is not correct.

Before:
```javascript
{ [ValidationError: Integer validation failed]
  message: 'Integer validation failed',
  name: 'ValidationError',
  errors: 
   { 'nested.0.value': 
      { [ValidatorError: Error, expected `value` to be an integer. Value: `0.5`]
        message: 'Error, expected `value` to be an integer. Value: `0.5`',
        name: 'ValidatorError',
        properties: [Object],
        kind: 'user defined',
        path: 'value', // HERE
        value: 0.5 } } }
````

After correction:
````javascript
{ [ValidationError: Integer validation failed]
  message: 'Integer validation failed',
  name: 'ValidationError',
  errors: 
   { 'nested.0.value': 
      { [ValidatorError: Error, expected `nested.0.value` to be an integer. Value: `0.5`]
        message: 'Error, expected `nested.0.value` to be an integer. Value: `0.5`',
        name: 'ValidatorError',
        properties: [Object],
        kind: 'user defined',
        path: 'nested.0.value', // HERE
        value: 0.5 } } }
````

Also corrected unit test and add missing unit test for error property value field